### PR TITLE
Correct release date in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Change Log
 ==========
 
 
-Version 1.2 *(2013-04-03)*
+Version 1.2 *(2013-03-31)*
 --------------------------
 
 * Support brand new `Roboto Slab` typefaces by Google.


### PR DESCRIPTION
I'm not sure if April 3rd is correct but I'm sure March 20th isn't correct for the release date of v1.2.
