### PR TITLE
Fix example of removing unused font in gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ Gradle
 
 If you intend to use is not all fonts, the extra fonts can be removed.
 
-``` xml
+``` gradle
 android.applicationVariants.all{ variant ->
-    variant.mergeAssets.doFirst {
-        File fonts = file("${projectDir}/build/intermediates/exploded-aar/com.github.johnkil.android-robototextview/robototextview/2.5.1/assets/fonts")
+    variant.mergeAssets.doLast {
+        File fonts = file("$variant.mergeAssets.outputDir/fonts")
         if (fonts.exists()) {
             for (File file : fonts.listFiles()) {
                 if (file.getName().contains("RobotoSlab")) {


### PR DESCRIPTION
Latest android gradle plugin changed behavior of dependency.

Now we remove font after `mergeAssets` and use `mergeAssets.outputDir` instead of hardcoded path